### PR TITLE
Fix issues on Firefox

### DIFF
--- a/src/floaty.tsx
+++ b/src/floaty.tsx
@@ -370,7 +370,7 @@ export class Floaty<T> extends React.PureComponent<Props<T>, State<T>> implement
         if ('eventTarget' in options) {
             this.registerFloatHandlers(options.eventTarget);
         } else if ('event' in options) {
-            if (options.event instanceof TouchEvent && options.event.target && options.event.target instanceof HTMLElement) {
+            if (window.TouchEvent && options.event instanceof TouchEvent && options.event.target && options.event.target instanceof HTMLElement) {
                 // Touch events should be re-registered with their event target, otherwise the touchmove and touchup events will not fire.
                 this.registerFloatHandlers(options.event.target);
             } else {


### PR DESCRIPTION
This seems to solve an issue that on Firefox TouchEvent is not available on the global scope

https://stackoverflow.com/questions/27313488/touchevent-not-working-in-firefox-and-other-website-browser

And I think it is related to this point on the documentation:
https://developer.mozilla.org/en-US/docs/Web/API/Touch_events#Firefox_touch_events_and_multiprocess_e10s